### PR TITLE
fix: changes image width to px instead of percentage for IE

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -71,7 +71,7 @@ p {
   padding: 0 0 0.25rem 0; }
   @media only screen and (min-width: 48rem) {
     .overview__image {
-      max-width: 20%;
+      max-width: 150px;
       padding-right: 2rem; } }
 
 .download {

--- a/app/scss/_components.scss
+++ b/app/scss/_components.scss
@@ -17,7 +17,7 @@
   padding: 0 0 0.25rem 0;
 
   @include breakpoint-medium {
-    max-width: 20%;
+    max-width: 150px;
     padding-right: 2rem;
   }
 }


### PR DESCRIPTION
IE was stretching the image horizontally when using a percentage for max-width. Changing it to a px value is 👍 